### PR TITLE
Automatic assign mac to peer id 

### DIFF
--- a/bcache.go
+++ b/bcache.go
@@ -19,28 +19,6 @@ type Bcache struct {
 	logger Logger
 }
 
-// Config represents bcache configuration
-type Config struct {
-	// PeerID is unique ID of this bcache
-	PeerID uint64
-
-	// ListenAddr is listen addr of this bcache peer.
-	// used to communicate with other peers
-	ListenAddr string
-
-	// Peers is the address of the known peers.
-	// we don't need to know all of the other peers,
-	// gossip protocol will find the other peers
-	Peers []string
-
-	// MaxKeys defines max number of keys in this cache
-	MaxKeys int
-
-	// Logger to be used
-	// leave it nil to use default logger which do nothing
-	Logger Logger
-}
-
 // New creates new bcache from the given config
 func New(cfg Config) (*Bcache, error) {
 	const (
@@ -49,24 +27,14 @@ func New(cfg Config) (*Bcache, error) {
 
 	var (
 		peerName mesh.PeerName
+		err      error
 		nickName = cfg.ListenAddr
 		logger   = cfg.Logger
 	)
 
-	if cfg.PeerID == uint64(0) {
-		mac, err := getMacAddress()
-		if err != nil {
-			return nil, err
-		}
-
-		pName, err := mesh.PeerNameFromString(mac)
-		if err != nil {
-			return nil, err
-		}
-
-		peerName = pName
-	} else {
-		peerName = mesh.PeerName(cfg.PeerID)
+	peerName, err = cfg.setPeer()
+	if err != nil {
+		return nil, err
 	}
 
 	// if logger is nil, create default nopLogger

--- a/bcache.go
+++ b/bcache.go
@@ -27,15 +27,16 @@ func New(cfg Config) (*Bcache, error) {
 
 	var (
 		peerName mesh.PeerName
-		err      error
 		nickName = cfg.ListenAddr
 		logger   = cfg.Logger
 	)
 
-	peerName, err = cfg.setPeer()
-	if err != nil {
+	if err := cfg.setDefault(); err != nil {
 		return nil, err
 	}
+
+	// set peer name
+	peerName = mesh.PeerName(cfg.PeerID)
 
 	// if logger is nil, create default nopLogger
 	if logger == nil {

--- a/bcache.go
+++ b/bcache.go
@@ -48,10 +48,26 @@ func New(cfg Config) (*Bcache, error) {
 	)
 
 	var (
-		peerName = mesh.PeerName(cfg.PeerID)
+		peerName mesh.PeerName
 		nickName = cfg.ListenAddr
 		logger   = cfg.Logger
 	)
+
+	if cfg.PeerID == uint64(0) {
+		mac, err := getMacAddress()
+		if err != nil {
+			return nil, err
+		}
+
+		pName, err := mesh.PeerNameFromString(mac)
+		if err != nil {
+			return nil, err
+		}
+
+		peerName = pName
+	} else {
+		peerName = mesh.PeerName(cfg.PeerID)
+	}
 
 	// if logger is nil, create default nopLogger
 	if logger == nil {

--- a/bcache_test.go
+++ b/bcache_test.go
@@ -19,7 +19,6 @@ func TestSimple(t *testing.T) {
 		val2 = "val2"
 	)
 	b1, err := New(Config{
-		PeerID:     1,
 		ListenAddr: "127.0.0.1:12345",
 		Peers:      nil,
 		MaxKeys:    1000,

--- a/bcache_test.go
+++ b/bcache_test.go
@@ -110,3 +110,32 @@ func TestJoinLater(t *testing.T) {
 		require.Equal(t, v, got)
 	}
 }
+
+func TestValidationError(t *testing.T) {
+	// invalid address because no port
+	c := Config{
+		PeerID:     1,
+		ListenAddr: "127.0.0.1",
+		Peers:      nil,
+		MaxKeys:    1000,
+		Logger:     logrus.New(),
+	}
+
+	_, err := New(c)
+	require.Error(t, err)
+
+	// invalid address because wrong port
+	c.ListenAddr = "127.0.0.1:abcd"
+	_, err = New(c)
+	require.Error(t, err)
+
+	// null logger not cause error
+	c.Logger = nil
+	c.ListenAddr = "127.0.0.1:12666"
+
+	b1, err := New(c)
+	require.NoError(t, err)
+	require.NotNil(t, b1)
+	defer b1.Close()
+
+}

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import "github.com/weaveworks/mesh"
 // Config represents bcache configuration
 type Config struct {
 	// PeerID is unique ID of this bcache
+	// if PeerID = 0, it will be set using mac address
 	PeerID uint64
 
 	// ListenAddr is listen addr of this bcache peer.
@@ -24,20 +25,19 @@ type Config struct {
 	Logger Logger
 }
 
-func (c *Config) setPeer() (mesh.PeerName, error) {
-	if c.PeerID != uint64(0) {
-		return mesh.PeerName(c.PeerID), nil
-	}
+func (c *Config) setDefault() error {
+	if c.PeerID == uint64(0) {
+		mac, err := getMacAddress()
+		if err != nil {
+			return err
+		}
 
-	mac, err := getMacAddress()
-	if err != nil {
-		return mesh.PeerName(0), err
-	}
+		pName, err := mesh.PeerNameFromString(mac)
+		if err != nil {
+			return err
+		}
 
-	pName, err := mesh.PeerNameFromString(mac)
-	if err != nil {
-		return mesh.PeerName(0), err
+		c.PeerID = uint64(pName)
 	}
-
-	return pName, nil
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,43 @@
+package bcache
+
+import "github.com/weaveworks/mesh"
+
+// Config represents bcache configuration
+type Config struct {
+	// PeerID is unique ID of this bcache
+	PeerID uint64
+
+	// ListenAddr is listen addr of this bcache peer.
+	// used to communicate with other peers
+	ListenAddr string
+
+	// Peers is the address of the known peers.
+	// we don't need to know all of the other peers,
+	// gossip protocol will find the other peers
+	Peers []string
+
+	// MaxKeys defines max number of keys in this cache
+	MaxKeys int
+
+	// Logger to be used
+	// leave it nil to use default logger which do nothing
+	Logger Logger
+}
+
+func (c *Config) setPeer() (mesh.PeerName, error) {
+	if c.PeerID != uint64(0) {
+		return mesh.PeerName(c.PeerID), nil
+	}
+
+	mac, err := getMacAddress()
+	if err != nil {
+		return mesh.PeerName(0), err
+	}
+
+	pName, err := mesh.PeerNameFromString(mac)
+	if err != nil {
+		return mesh.PeerName(0), err
+	}
+
+	return pName, nil
+}

--- a/config_test.go
+++ b/config_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-	"github.com/weaveworks/mesh"
 )
 
 func TestConfig(t *testing.T) {
@@ -17,9 +16,9 @@ func TestConfig(t *testing.T) {
 		Logger:     logrus.New(),
 	}
 
-	p, err := c.setPeer()
+	err := c.setDefault()
 	require.NoError(t, err)
-	require.NotEqual(t, mesh.PeerName(uint64(0)), p)
+	require.NotEqual(t, uint64(0), c.PeerID)
 
 	// should be using predefined id
 	cfgManual := Config{
@@ -30,7 +29,7 @@ func TestConfig(t *testing.T) {
 		PeerID:     uint64(2),
 	}
 
-	pMan, err := cfgManual.setPeer()
+	err = cfgManual.setDefault()
 	require.NoError(t, err)
-	require.Equal(t, mesh.PeerName(uint64(2)), pMan)
+	require.Equal(t, uint64(2), cfgManual.PeerID)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,36 @@
+package bcache
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/weaveworks/mesh"
+)
+
+func TestConfig(t *testing.T) {
+	// should be using mac addr
+	c := Config{
+		ListenAddr: "127.0.0.1:12345",
+		Peers:      nil,
+		MaxKeys:    1000,
+		Logger:     logrus.New(),
+	}
+
+	p, err := c.setPeer()
+	require.NoError(t, err)
+	require.NotEqual(t, mesh.PeerName(uint64(0)), p)
+
+	// should be using predefined id
+	cfgManual := Config{
+		ListenAddr: "127.0.0.1:12345",
+		Peers:      nil,
+		MaxKeys:    1000,
+		Logger:     logrus.New(),
+		PeerID:     uint64(2),
+	}
+
+	pMan, err := cfgManual.setPeer()
+	require.NoError(t, err)
+	require.Equal(t, mesh.PeerName(uint64(2)), pMan)
+}

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,10 @@
+package bcache
+
+import "testing"
+
+func TestLog(t *testing.T) {
+	logger := &nopLogger{}
+	logger.Errorf("Nothing %s", "nothing")
+	logger.Printf("Nothing %s", "nothing")
+	logger.Debugf("Nothing %s", "nothing")
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,26 @@
+package bcache
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errMacAddressNotFound = errors.New("mac address not found in this machine")
+)
+
+// getMacAddress get mac address of this machine
+func getMacAddress() (string, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+
+	for _, intf := range interfaces {
+		if intf.Flags&net.FlagUp != 0 && intf.HardwareAddr != nil {
+			return intf.HardwareAddr.String(), nil
+		}
+	}
+
+	return "", errMacAddressNotFound
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,13 @@
+package bcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMacAddress(t *testing.T) {
+	mac, err := getMacAddress()
+	require.NoError(t, err)
+	require.NotEqual(t, "", mac)
+}


### PR DESCRIPTION
Fixes #6 
* Automatic assign peerID  using mac address if user does not assign peerID manually