### PR TITLE
Rework expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@
 [![codecov](https://codecov.io/gh/iwanbk/bcache/branch/master/graph/badge.svg)](https://codecov.io/gh/iwanbk/bcache)
 [![Go Report Card](https://goreportcard.com/badge/github.com/iwanbk/bcache)](https://goreportcard.com/report/github.com/iwanbk/bcache)
 
-A Go Library to create distributed in-memory cache.
-
-It uses [Gossip Protocol](https://en.wikipedia.org/wiki/Gossip_protocol) for data synchronization between peers.
+A Go Library to create distributed in-memory cache inside your app.
 
 ## Features
 
 - LRU cache with configurable maximum keys
 - Eventual Consistency synchronization between peers
-- Data are replicated to all peers
+- Data are replicated to all nodes
 - cache filling mechanism. When the cache of the given key is not exist, bcache coordinates cache fills such that only one call populates the cache to avoid thundering herd or [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede)
 
 ## Why using it
@@ -22,10 +20,25 @@ It uses [Gossip Protocol](https://en.wikipedia.org/wiki/Gossip_protocol) for dat
 - you only need cache with simple `Set` & `Get` operation
 - you have enough RAM to hold the cache data
 
-## Credits
+## How it Works
 
-- [weaveworks/mesh](https://github.com/weaveworks/mesh) for the gossip library
-- [groupcache](https://github.com/golang/groupcache) for the inspiration
+1. Nodes find each other using [Gossip Protocol](https://en.wikipedia.org/wiki/Gossip_protocol)
+
+Only need to specify one or few nodes as bootstrap nodes, and all nodes will find each other using gossip protocol
+
+2. When there is cache `set`, the event will be propagated to all of the nodes.
+
+So, all of the nodes will have synced data.
+
+
+## Expiration
+
+Although this library doesn't invalidate the keys when it reachs the expiration time,
+the expiration timestamp will be used as a way to decide which value is the newer when doing data synchronization
+among nodes.
+
+So, it is `mandatory` to set the expiration time.
+
 
 ## Cache filling
 
@@ -104,3 +117,7 @@ if err != nil {
 val, exists := bc.Get("my_key2")
 ```
 
+## Credits
+
+- [weaveworks/mesh](https://github.com/weaveworks/mesh) for the gossip library
+- [groupcache](https://github.com/golang/groupcache) for the inspiration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://travis-ci.org/iwanbk/bcache.svg?branch=master)](https://travis-ci.org/iwanbk/bcache)
 [![codecov](https://codecov.io/gh/iwanbk/bcache/branch/master/graph/badge.svg)](https://codecov.io/gh/iwanbk/bcache)
 [![Go Report Card](https://goreportcard.com/badge/github.com/iwanbk/bcache)](https://goreportcard.com/report/github.com/iwanbk/bcache)
+[![CodeFactor](https://www.codefactor.io/repository/github/iwanbk/bcache/badge)](https://www.codefactor.io/repository/github/iwanbk/bcache)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0535095fdd215f2e22ad/maintainability)](https://codeclimate.com/github/iwanbk/bcache/maintainability)
 
 A Go Library to create distributed in-memory cache inside your app.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Although this library doesn't invalidate the keys when it reachs the expiration 
 the expiration timestamp will be used as a way to decide which value is the newer when doing data synchronization
 among nodes.
 
-So, it is `mandatory` to set the expiration time.
+So, it is **mandatory** to set the expiration time.
 
 
 ## Cache filling
@@ -58,12 +58,11 @@ c, err := New(Config{
 	ListenAddr: "192.168.0.3:12345",
 	Peers:      []string{"192.168.0.1:12345"},
 	MaxKeys:    1000,
-	Logger:     logrus.New(),
 })
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-val, exists,err  := bc.GetWithFiller("my_key2",func(key string) (string, int64, error) {
+val, exp,err  := bc.GetWithFiller("my_key2",func(key string) (string, int64, error) {
         // get value from database
          .....
          //
@@ -77,14 +76,14 @@ In server 1
 bc, err := New(Config{
 	// PeerID:     1, // leave it, will be set automatically based on mac addr
 	ListenAddr: "192.168.0.1:12345",
-	Peers:      nil,
+	Peers:      nil, // it nil because we will use this node as bootstrap node
 	MaxKeys:    1000,
 	Logger:     logrus.New(),
 })
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-bc.Set("my_key", "my_val")
+bc.Set("my_key", "my_val",12345)
 ```
 
 In server 2
@@ -99,7 +98,7 @@ bc, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-bc.Set("my_key2", "my_val2")
+bc.Set("my_key2", "my_val2", 12345)
 ```
 
 In server 3
@@ -114,7 +113,7 @@ bc, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-val, exists := bc.Get("my_key2")
+val, exp, exists := bc.Get("my_key2")
 ```
 
 ## Credits

--- a/cache.go
+++ b/cache.go
@@ -2,7 +2,7 @@ package bcache
 
 import (
 	"sync"
-	"time"
+	//"time"
 
 	"github.com/hashicorp/golang-lru"
 	"github.com/weaveworks/mesh"
@@ -51,19 +51,8 @@ func (c *cache) get(key string) (string, int64, bool) {
 }
 
 // Get gets cache value of the given key
-func (c *cache) Get(key string) (string, bool) {
-	val, expired, ok := c.get(key)
-	if !ok {
-		return "", false
-	}
-	// check for expiration
-	if expired > 0 && time.Now().Unix() > expired {
-		c.cc.Remove(key)
-		return "", false
-	}
-
-	return val, true
-
+func (c *cache) Get(key string) (string, int64, bool) {
+	return c.get(key)
 }
 
 // merges received data into state and returns a
@@ -95,8 +84,8 @@ func (c *cache) mergeChange(msg *message) (delta mesh.GossipData, changedKey int
 
 	var existingKeys []string
 	for _, e := range msg.Entries {
-		val, ok := c.cc.Get(e.Key)
-		if ok && val == e.Val {
+		_, exp, ok := c.get(e.Key)
+		if ok && exp < e.Expired {
 			existingKeys = append(existingKeys, e.Key)
 			continue
 		}

--- a/peer.go
+++ b/peer.go
@@ -124,7 +124,7 @@ func (p *peer) Set(key, val string, expiredTimestamp int64) {
 	<-c // wait for it to be finished
 }
 
-func (p *peer) Get(key string) (string, bool) {
+func (p *peer) Get(key string) (string, int64, bool) {
 	return p.cc.Get(key)
 }
 


### PR DESCRIPTION
Fixes #17

`Get()`  now returns expiration time. 

Expiration time will also be used to decide which value is the newer when doing data sync among nodes.