### PR TITLE
Bcache now handles key expiration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,30 +27,10 @@ A Go Library to create distributed in-memory cache inside your app.
 
 Only need to specify one or few nodes as bootstrap nodes, and all nodes will find each other using gossip protocol
 
-2. When there is cache `set`, the event will be propagated to all of the nodes.
+2. When there is cache `Set` and `Delete`, the event will be propagated to all of the nodes.
 
-So, all of the nodes will have synced data.
+So, all of the nodes will eventually have synced data.
 
-
-## Expiration
-
-Although this library doesn't invalidate the keys when it reachs the expiration time,
-the expiration timestamp will be used in these ways:
-
-(1) On `Set`:
-- as a way to decide which value is the newer when doing data synchronization among nodes
-- set timestamp expiration
-
-(2) On `Get`:
-- the expiration timestamp could be used to check whether the key has been expired
-
-(3) On `Delete`:
-- to decide which operation is the lastes when doing syncronization, for example:
-	- `Delete` with timestamp 3 and `Set` with timestamp 4 -> `Set` is the latest, so the `Delete` is ignored
-
-So, it is **mandatory** to set the expiration time and the delta from current time must be the same
-between `Set` and `Delete`.
-We can also use [UnixNano](https://golang.org/pkg/time/#Time.UnixNano) for better precission than `Unix`.
 
 
 ## Cache filling
@@ -79,7 +59,7 @@ bc, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-bc.Set("my_key", "my_val",12345)
+bc.Set("my_key", "my_val",86400)
 ```
 
 In server 2
@@ -94,7 +74,7 @@ bc, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-bc.Set("my_key2", "my_val2", 12345)
+bc.Set("my_key2", "my_val2", 86400)
 ```
 
 In server 3
@@ -109,7 +89,7 @@ bc, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-val, exp, exists := bc.Get("my_key2")
+val, exists := bc.Get("my_key2")
 ```
 
 ### GetWithFiller example
@@ -124,12 +104,12 @@ c, err := New(Config{
 if err != nil {
     log.Fatalf("failed to create cache: %v", err)
 }
-val, exp,err  := bc.GetWithFiller("my_key2",func(key string) (string, int64, error) {
+val, exp,err  := bc.GetWithFiller("my_key2",func(key string) (string, error) {
         // get value from database
          .....
          //
 		return value, 0, nil
-})
+}, 86400)
 ```
 
 ## Credits

--- a/config.go
+++ b/config.go
@@ -2,6 +2,10 @@ package bcache
 
 import "github.com/weaveworks/mesh"
 
+const (
+	defaultDeletionDelay = 100 // default deletion delay : 100 seconds
+)
+
 // Config represents bcache configuration
 type Config struct {
 	// PeerID is unique ID of this bcache
@@ -23,6 +27,12 @@ type Config struct {
 	// Logger to be used
 	// leave it nil to use default logger which do nothing
 	Logger Logger
+
+	// DeletionDelay adds delay before actually delete the key,
+	// it is used to handle temporary network connection issue,
+	// which could prevent data syncing between nodes.
+	// Leave it to 0 make it use default value: 100 seconds.
+	DeletionDelay int
 }
 
 func (c *Config) setDefault() error {
@@ -39,6 +49,10 @@ func (c *Config) setDefault() error {
 		}
 
 		c.PeerID = uint64(pName)
+	}
+
+	if c.DeletionDelay <= 0 {
+		c.DeletionDelay = defaultDeletionDelay
 	}
 
 	// if logger is nil, create default nopLogger

--- a/message.go
+++ b/message.go
@@ -24,7 +24,7 @@ type entry struct {
 	Key     string
 	Val     string
 	Expired int64
-	Deleted bool
+	Deleted int64
 }
 
 func newMessage(peerID mesh.PeerName, numEntries int) *message {
@@ -47,7 +47,7 @@ func newMessageFromBuf(b []byte) (*message, error) {
 	return &m, err
 }
 
-func (m *message) add(key, val string, expired int64, deleted bool) {
+func (m *message) add(key, val string, expired, deleted int64) {
 	m.mux.Lock()
 	m.Entries[key] = entry{
 		Key:     key,
@@ -82,6 +82,10 @@ func (m *message) mergeComplete(other *message) mesh.GossipData {
 
 	for k, v := range other.Entries {
 		existing, ok := m.Entries[k]
+
+		// merge
+		// - the key not exists in
+		// - has less expiration time
 		if !ok || existing.Expired < v.Expired {
 			m.Entries[k] = v
 		}

--- a/peer_test.go
+++ b/peer_test.go
@@ -129,7 +129,7 @@ func TestPeerOnGossip(t *testing.T) {
 				"key1": {
 					Key:     "key1",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 			delta: map[string]entry{
@@ -137,7 +137,7 @@ func TestPeerOnGossip(t *testing.T) {
 					Key:     "key1",
 					Val:     "",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 		},
@@ -294,7 +294,7 @@ func TestPeerOnGossipBroadcast(t *testing.T) {
 				"key1": {
 					Key:     "key1",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 			delta: map[string]entry{
@@ -302,7 +302,7 @@ func TestPeerOnGossipBroadcast(t *testing.T) {
 					Key:     "key1",
 					Val:     "",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 		},
@@ -472,7 +472,7 @@ func TestPeerOnGossipUnicast(t *testing.T) {
 				"key1": {
 					Key:     "key1",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 			complete: map[string]entry{
@@ -480,7 +480,7 @@ func TestPeerOnGossipUnicast(t *testing.T) {
 					Key:     "key1",
 					Val:     "",
 					Expired: 2,
-					Deleted: true,
+					Deleted: 1,
 				},
 			},
 		},


### PR DESCRIPTION
key points:

- expiration will be handled by bcache, previous version which basically do nothing with expiration
- passive key deletion, data deleted when `Get` found that the key is expired. No GC-like mechanism at this phase, could be added later if needed
- deletion delay: add delay before actually delete the key, it is used to handle temporary network connection issue, which prevent data syncing between nodes
- specify ttl instead of expirationTimestamp

Fixes #23