### PR TITLE
Add integration test build tag.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
 script:
   - go build
   - go test -race -coverprofile=coverage.txt -covermode=atomic
+
+  # execute integration test without `-race` flag, as it is not thread safe
+  # caused by issue on https://github.com/weaveworks/mesh/pull/98
   - go test -tags integration -coverprofile=coverage.txt -covermode=atomic
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
 
 script:
   - go build
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+  - go test -tags integration -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/bcache_test.go
+++ b/bcache_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package bcache
 
 import (


### PR DESCRIPTION
Because the integration test is not thread safe.
It is caused by https://github.com/weaveworks/mesh/pull/98